### PR TITLE
Enhance output options (`b:radical_bases`)

### DIFF
--- a/autoload/radical.vim
+++ b/autoload/radical.vim
@@ -10,7 +10,8 @@ let s:BASES = {
     \ 10: {'pattern': '\v(\d+)',
     \      'format': '%s'},
     \ 16: {'pattern': '\v\c%(0x)=(\x+)',
-    \      'format': '0x%s'}
+    \      'format': '0x%s',
+    \      'uppercase': 0 }
     \ }
 
 function! s:Error(message) abort
@@ -52,7 +53,13 @@ endfunction
 
 function! s:IntegerToString(integer, base, ...) abort
   let l:format = a:0 ? (s:BasesForBuffer()[a:base].format) : '%s'
-  return printf(l:format, a:integer.String(a:base))
+  let l:str = a:integer.String(a:base)
+
+  if get(s:BasesForBuffer()[a:base], 'uppercase', v:false)
+    let l:str = l:str->toupper()
+  endif
+
+  return printf(l:format, l:str)
 endfunction
 
 function! s:GuessBase(numberstring) abort

--- a/autoload/radical.vim
+++ b/autoload/radical.vim
@@ -71,7 +71,7 @@ function! s:IntegerToString(integer, base, ...) abort
         let l:expbit = 8
         let l:extrabit = a:base ==# 16 ? 16 : 8
         while l:expbit < l:bit
-          if l:expbit < v:numbersize
+          if l:expbit < get(v:, 'numbersize', 64)
             let l:expbit = l:expbit * 2
           else
             let l:expbit = l:expbit + l:extrabit

--- a/autoload/radical.vim
+++ b/autoload/radical.vim
@@ -33,13 +33,20 @@ function! s:NumberStringToInteger(numberstring, base) abort
 endfunction
 
 function! s:BasesForBuffer() abort
-  if !has_key(b:, 'radical_bases')
-    return s:BASES
-  endif
   let l:bases = deepcopy(s:BASES)
-  for [l:base, l:settings] in items(b:radical_bases)
-    call extend(l:bases[l:base], l:settings)
-  endfor
+
+  if has_key(g:, 'radical_bases')
+    for [l:base, l:settings] in items(g:radical_bases)
+      call extend(l:bases[l:base], l:settings)
+    endfor
+  endif
+
+  if has_key(b:, 'radical_bases')
+    for [l:base, l:settings] in items(b:radical_bases)
+      call extend(l:bases[l:base], l:settings)
+    endfor
+  endif
+
   return l:bases
 endfunction
 

--- a/doc/radical.txt
+++ b/doc/radical.txt
@@ -38,7 +38,8 @@ For all mappings the base of the target number can be forced by giving a
 count.  For example, "16gA" targets a hexadecimal number.
 
 Coercion output can be controlled by specifying a format string for each base
-in the buffer-local Dictionary "b:radical_bases".  It should look like this: >
+in the buffer-local Dictionary "b:radical_bases", or global Dictionary
+"g:radical_bases".  It should look like this: >
     {8: {'format': '0o%s'}}
 
 All default mappings can be suppressed by setting "g:radical_no_mappings" in


### PR DESCRIPTION
Fix for <https://github.com/glts/vim-radical/issues/11> and <https://github.com/glts/vim-radical/issues/12>.

- Add `g:radical_bases` option besides `b:radical_bases`
    - `b:radical_bases` settins are preferred, if exist
- Add options for each base entries of `{g,b}:radical_bases`
    - `upper` (boolean flag)
        - for <https://github.com/glts/vim-radical/issues/11>
        - Output in upper case (`0xff` -> `0xFF`; for hex)
    - `align` (boolean flag)
        - for <https://github.com/glts/vim-radical/issues/12>
        - Align values with 0-fill
            - If hex (base = 16),
              Align in 8 -> 16 -> 32 -> 64 bits length, and + 16 bits if more longer
              (i.e. 2 -> 4 -> 8 -> 16 char length, and + 2 chars)
            - If bin (base = 2),
              Align in 8 -> 16 -> 32 -> 64 bits length, and + 8 bits if more longer
            - If octal (base = 8),
              Align in every 3 char length

To try, set as below:

```vim
let g:radical_bases = { 16 : { 'upper' : 1, 'align' : 1 }, 8 : { 'format' : '0o%s', 'align' : 1 }, 2 : { 'align' : 1 } }
```

| Bits | Bytes | Before                | Hex                      | Bin                                                                          | Remarks                                                           |
|-----:|------:|:----------------------|:-------------------------|:-----------------------------------------------------------------------------|:------------------------------------------------------------------|
|    8 |     1 | `0xf`                 | `0x0F`                   | `0b00001111`                                                                 | `upper` option test                                               |
|    8 |     1 | `0x1`                 | `0x01`                   | `0b00000001`                                                                 | `char` size                                                       |
|   16 |     2 | `0x101`               | `0x0101`                 | `0b0000000100000001`                                                         | `short` size                                                      |
|   32 |     4 | `0x10101`             | `0x00010101`             | `0b00000000000000010000000100000001`                                         | `long` size                                                       |
|   64 |     8 | `0x100010101`         | `0x0000000100010101`     | `0b0000000000000000000000000000000100000000000000010000000100000001`         | `long long` size                                                  |
| more |       | `0x10000000100010101` | `0x00010000000100010101` | `0b000000010000000000000000000000000000000100000000000000010000000100000001` | If hex, grows by 2 bytes (4 chars) / if bin, by 1 bytes (8 chars) |

| Bits | Chars | Before   | Octal      | Remarks                   |
|-----:|------:|:---------|:-----------|:--------------------------|
|  ~ 9 |   ~ 3 | `0o1`    | `0o001`    |                           |
| more |       | `0o1001` | `0o001001` | Grows by 3 chars (9 bits) |
