### PR TITLE
Separate digits of decimal in `gA`

### DIFF
--- a/autoload/radical.vim
+++ b/autoload/radical.vim
@@ -117,7 +117,7 @@ function! s:PrintBaseInfo(integer, base) abort
   echomsg printf('<%s>%s  %s,  Hex %s,  Octal %s,  Binary %s',
       \ s:IntegerToString(a:integer, a:base),
       \ a:base is 10 ? '' : a:base,
-      \ s:IntegerToString(a:integer, 10),
+      \ substitute(s:IntegerToString(a:integer, 10), '\d\zs\ze\v(\d{3})+$', ' ', 'g'),
       \ s:Format(s:IntegerToString(a:integer, 16), 4),
       \ s:Format(s:IntegerToString(a:integer, 8), 3),
       \ s:Format(s:IntegerToString(a:integer, 2), 8),


### PR DESCRIPTION
Separate digit in decimal representation in `gA`.

##### Example

###### Old

```
<1>  1,  Hex 0001,  Octal 001,  Binary 00000001
<12>  12,  Hex 000C,  Octal 014,  Binary 00001100
<123>  123,  Hex 007B,  Octal 173,  Binary 01111011
<1234>  1234,  Hex 04D2,  Octal 002 322,  Binary 00000100 11010010
<12345>  12345,  Hex 3039,  Octal 030 071,  Binary 00110000 00111001
<123456>  123456,  Hex 0001 E240,  Octal 361 100,  Binary 00000000 00000001 11100010 01000000
<1234567>  1234567,  Hex 0012 D687,  Octal 004 553 207,  Binary 00000000 00010010 11010110 10000111
<12345678>  12345678,  Hex 00BC 614E,  Octal 057 060 516,  Binary 00000000 10111100 01100001 01001110
<123456789>  123456789,  Hex 075B CD15,  Octal 726 746 425,  Binary 00000111 01011011 11001101 00010101
```

###### New

```
<1>  1,  Hex 0001,  Octal 001,  Binary 00000001
<12>  12,  Hex 000C,  Octal 014,  Binary 00001100
<123>  123,  Hex 007B,  Octal 173,  Binary 01111011
<1234>  1 234,  Hex 04D2,  Octal 002 322,  Binary 00000100 11010010
<12345>  12 345,  Hex 3039,  Octal 030 071,  Binary 00110000 00111001
<123456>  123 456,  Hex 0001 E240,  Octal 361 100,  Binary 00000000 00000001 11100010 01000000
<1234567>  1 234 567,  Hex 0012 D687,  Octal 004 553 207,  Binary 00000000 00010010 11010110 10000111
<12345678>  12 345 678,  Hex 00BC 614E,  Octal 057 060 516,  Binary 00000000 10111100 01100001 01001110
<123456789>  123 456 789,  Hex 075B CD15,  Octal 726 746 425,  Binary 00000111 01011011 11001101 00010101
```
