### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
ignore tags file generated by vim

If I clone this repo to `.vim/pack/xx/start/vim-radical`, and run `helptags ALL` inside vim, a file named `doc/tags` will be created.